### PR TITLE
add caching poc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 Play around with spring-data 2.7.9
 
 Endpoint: http://localhost:8080/api/v1/myconfigs
+
+## Run database and admin with docker-compose
+
+Start PG and PG-Admin in docker:
+```
+$ docker-compose -f dockerpg/docker-compose.yml uo   
+```
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,30 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>org.springframework</groupId>-->
+<!--			<artifactId>spring-context</artifactId>-->
+<!--			<version>5.3.22</version>-->
+<!--		</dependency>-->
+<!--		<dependency>-->
+<!--			<groupId>org.springframework</groupId>-->
+<!--			<artifactId>spring-context-support</artifactId>-->
+<!--			<version>6.0.6</version>-->
+<!--		</dependency>-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+			<version>3.0.4</version>
+		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>org.springframework.boot</groupId>-->
+<!--			<artifactId>spring-boot-starter-cache</artifactId>-->
+<!--		</dependency>-->
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/ch/nostromo/springjpatests/SpringjpatestsApplication.java
+++ b/src/main/java/ch/nostromo/springjpatests/SpringjpatestsApplication.java
@@ -7,10 +7,12 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.stereotype.Component;
 
 @SpringBootApplication
 @Component
+@EnableCaching
 public class SpringjpatestsApplication implements ApplicationRunner {
 
 	@Autowired
@@ -23,7 +25,4 @@ public class SpringjpatestsApplication implements ApplicationRunner {
 	public static void main(String[] args) {
 		SpringApplication.run(SpringjpatestsApplication.class, args);
 	}
-
-
-
 }

--- a/src/main/java/ch/nostromo/springjpatests/controller/MyConfigController.java
+++ b/src/main/java/ch/nostromo/springjpatests/controller/MyConfigController.java
@@ -1,20 +1,23 @@
 package ch.nostromo.springjpatests.controller;
 
+import ch.nostromo.springjpatests.data.ConfigRepository;
 import ch.nostromo.springjpatests.data.MyConfig;
-import ch.nostromo.springjpatests.data.MyConfigRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1")
 public class MyConfigController {
 
     @Autowired
-    private MyConfigRepository myConfigRepository;
+    private ConfigRepository myConfigRepository;
 
     @GetMapping("/myconfigs")
     public List<MyConfig> myConfig() {
@@ -28,13 +31,28 @@ public class MyConfigController {
         myConfigRepository.findById(99L);
         myConfigRepository.findById(99L);
 
-
-
         return myConfigRepository.findAll();
-
     }
 
+    @GetMapping("/configs")
+    public List<Optional<MyConfig>> cachedConfig() {
+        Optional<MyConfig> cachedConfig = cachedConfigValue(1L);
+        Optional<MyConfig> plainConfig = configValue(1L);
+        ArrayList<Optional<MyConfig>> configs = new ArrayList<>();
+        configs.add(cachedConfig);
+        configs.add(plainConfig);
+        return configs;
+    }
 
+    @Cacheable("config")
+    public Optional<MyConfig> cachedConfigValue(long id) {
+        Optional<MyConfig> configValue = myConfigRepository.findById(id);
+        return configValue;
+    }
 
+    public Optional<MyConfig> configValue(long id) {
+        Optional<MyConfig> configValue = myConfigRepository.findByIdNoCache(id);
+        return configValue;
+    }
 
 }

--- a/src/main/java/ch/nostromo/springjpatests/data/CachedConfigRepository.java
+++ b/src/main/java/ch/nostromo/springjpatests/data/CachedConfigRepository.java
@@ -1,0 +1,47 @@
+package ch.nostromo.springjpatests.data;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class CachedConfigRepository implements ConfigRepository {
+
+    @Autowired
+    private MyConfigRepository myConfigRepository;
+
+    private int cacheCallCounter = 0;
+    private int noCacheCallCounter = 0;
+
+    @Override
+    @Cacheable("config")
+    public Optional<MyConfig> findById(long id) {
+        System.out.println("###### calling CACHE config ######");
+        cacheCallCounter += 1;
+        Optional<MyConfig> byId = myConfigRepository.findById(id);
+        byId.get().cacheMark = cacheCallCounter;
+        return byId;
+    }
+
+    @Override
+    public Optional<MyConfig> findByIdNoCache(long id) {
+        System.out.println("###### calling NO-CACHE config ######");
+        noCacheCallCounter += 1;
+        Optional<MyConfig> byId = myConfigRepository.findById(id);
+        byId.get().cacheMark = noCacheCallCounter;
+        return byId;
+    }
+
+    @Override
+    public List<MyConfig> findAll() {
+        return myConfigRepository.findAll();
+    }
+
+    @Override
+    public void save(MyConfig myConfig) {
+        myConfigRepository.save(myConfig);
+    }
+}

--- a/src/main/java/ch/nostromo/springjpatests/data/ConfigRepository.java
+++ b/src/main/java/ch/nostromo/springjpatests/data/ConfigRepository.java
@@ -1,0 +1,17 @@
+package ch.nostromo.springjpatests.data;
+
+import org.springframework.cache.annotation.Cacheable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ConfigRepository {
+
+    Optional<MyConfig> findById(long id);
+
+    Optional<MyConfig> findByIdNoCache(long id);
+
+    List<MyConfig> findAll();
+
+    void save(MyConfig myConfig);
+}

--- a/src/main/java/ch/nostromo/springjpatests/data/MyConfig.java
+++ b/src/main/java/ch/nostromo/springjpatests/data/MyConfig.java
@@ -4,10 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 @Data
@@ -15,10 +12,18 @@ import javax.persistence.Id;
 @NoArgsConstructor
 public class MyConfig {
 
+    public MyConfig(Long id, String value) {
+        this.id = id;
+        this.value = value;
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     Long id;
 
     String value;
+
+    @Transient
+    public int cacheMark;
 
 }

--- a/src/main/java/ch/nostromo/springjpatests/data/MyConfigRepository.java
+++ b/src/main/java/ch/nostromo/springjpatests/data/MyConfigRepository.java
@@ -1,8 +1,7 @@
 package ch.nostromo.springjpatests.data;
 
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface  MyConfigRepository extends JpaRepository<MyConfig, Long> {}
+public interface MyConfigRepository extends JpaRepository<MyConfig, Long> {}


### PR DESCRIPTION
PoC für ein Caching auf der Repository Ebene. Damit können wir einfach die Config-Werte cachen, ohne dass die DB tatsächlich immer angefragt werden muss. 